### PR TITLE
pause and resume are not needed for win32 platform

### DIFF
--- a/lib/adapters/node-serialport.js
+++ b/lib/adapters/node-serialport.js
@@ -55,13 +55,13 @@ function write (data, callback) {
 }
 
 function pause () {
-    if (process.platform !== 'win32') {
+    if (this._sp.pause instanceof Function) {
         this._sp.pause();
     }
 }
 
 function resume () {
-    if (process.platform !== 'win32') {
+    if (this._sp.resume instanceof Function) {
         this._sp.resume();
     }
 }

--- a/lib/adapters/node-serialport.js
+++ b/lib/adapters/node-serialport.js
@@ -55,11 +55,15 @@ function write (data, callback) {
 }
 
 function pause () {
-  this._sp.pause();
+    if (process.platform !== 'win32') {
+        this._sp.pause();
+    }
 }
 
 function resume () {
-  this._sp.resume();
+    if (process.platform !== 'win32') {
+        this._sp.resume();
+    }
 }
 
 /**


### PR DESCRIPTION
In node-serialport, these 2 functions are not defined if running on Win32 which causes an exception. Therefore, protecting the call to these functions is necessary here to avoid the exception.
